### PR TITLE
file 'composer.lock' added to git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ npm-debug.log
 yarn-error.log
 /.idea
 /.vscode
-composer.lock
 #docker
 /docker/volumes/Nginx/logs
 /docker/volumes/MySQL/lib


### PR DESCRIPTION
Если не хранить в репозитории composer.lock, то при разворачивании демо проекта на локалке возникает несоответствие ассетов в проекте и актуальных ассетов последней версии муншайна, которые публикуются в проект при установке зависимостей.
Поэтому лучше жестко фиксировать в проекте версии пакетов, в частности moonshine.